### PR TITLE
Updated elgohr/Publish-Docker-Github-Action to a supported version (v5)

### DIFF
--- a/GridScanner/.github/workflows/build.yaml
+++ b/GridScanner/.github/workflows/build.yaml
@@ -11,7 +11,7 @@ jobs:
       id: get_version
       run: echo ::set-env name=RELEASE_VERSION::$(echo ${GITHUB_SHA})
     - name: Publish to Registry
-      uses: elgohr/Publish-Docker-Github-Action@master
+      uses: elgohr/Publish-Docker-Github-Action@v5
       with:
         name: jvenom/gridscanner
         username: ${{ secrets.DOCKER_USERNAME }}

--- a/InvoicePlaceholder/.github/workflows/build.yaml
+++ b/InvoicePlaceholder/.github/workflows/build.yaml
@@ -11,7 +11,7 @@ jobs:
       id: get_version
       run: echo ::set-env name=RELEASE_VERSION::$(echo ${GITHUB_SHA})
     - name: Publish to Registry
-      uses: elgohr/Publish-Docker-Github-Action@master
+      uses: elgohr/Publish-Docker-Github-Action@v5
       with:
         name: jvenom/invoiceplaceholder
         username: ${{ secrets.DOCKER_USERNAME }}


### PR DESCRIPTION
elgohr/Publish-Docker-Github-Action@master is not supported anymore